### PR TITLE
Disable sessions and cookies

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -1,3 +1,2 @@
 class Api::V1::ApplicationController < ApplicationController
-  skip_before_action :verify_authenticity_token
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::Base
+  skip_forgery_protection
+  before_action { request.session_options[:skip] = true }
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
       <%= meta_title %>
     </title>
     <meta name="description" content="<%= meta_description %>">
-    <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,10 @@ module Diff
     config.load_defaults 7.0
     config.exceptions_app = routes
 
+    config.session_store :disabled
+    config.middleware.delete ActionDispatch::Session::CookieStore
+    config.middleware.delete ActionDispatch::Cookies
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 require 'sidekiq/web'
 
 Sidekiq::Web.use ActionDispatch::Cookies
-Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_diff_sidekiq_session', path: '/sidekiq'
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_diff_sidekiq_session', path: '/sidekiq', secure: Rails.env.production?
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 require 'sidekiq/web'
 
+Sidekiq::Web.use ActionDispatch::Cookies
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_diff_sidekiq_session', path: '/sidekiq'
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))

--- a/test/controllers/cache_headers_test.rb
+++ b/test/controllers/cache_headers_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class CacheHeadersTest < ActionDispatch::IntegrationTest
+  test 'html pages do not set cookies' do
+    get root_path
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+end


### PR DESCRIPTION
`csrf_meta_tags` in the layout writes `_csrf_token` to the session on every render, which forces a `Set-Cookie: _diff_session=...` header on every response. Cloudflare (with origin cache control) returns `cf-cache-status: BYPASS` for responses carrying `Set-Cookie`, and APISIX `proxy-cache` never stores them:

```
$ curl -sI https://diff.ecosyste.ms/
set-cookie: _diff_session=...
apisix-cache-status: MISS
cf-cache-status: BYPASS
```

There's no login on this app, so:

- `config.session_store :disabled` and remove `ActionDispatch::Cookies` / `Session::CookieStore` from the middleware stack
- drop `csrf_meta_tags` from the layout
- `skip_forgery_protection` + `request.session_options[:skip] = true` in `ApplicationController`
- remove the now-redundant `skip_before_action :verify_authenticity_token` from `Api::V1::ApplicationController` (raises once the parent skips it)
- give `Sidekiq::Web` its own session middleware scoped to `/sidekiq` so retry/delete buttons keep working behind basic auth
- test asserting no `Set-Cookie` on the homepage

No `expires_in` added here since traffic is job POSTs and job-status GETs which shouldn't be cached; this just stops the cookie so the homepage and static assets can cache.

Same change as ecosyste-ms/awesome#793.